### PR TITLE
Context & Definition Classes

### DIFF
--- a/src/AbstractKeyValueStore.php
+++ b/src/AbstractKeyValueStore.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\Upward;
 
-abstract class AbstractKeyValueStore
+abstract class AbstractKeyValueStore implements \JsonSerializable
 {
     /**
      * @var array
@@ -72,6 +72,16 @@ abstract class AbstractKeyValueStore
         }
 
         return true;
+    }
+
+    /**
+     * Data to include when serializing to JSON.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArary();
     }
 
     /**

--- a/src/AbstractKeyValueStore.php
+++ b/src/AbstractKeyValueStore.php
@@ -81,7 +81,7 @@ abstract class AbstractKeyValueStore implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        return $this->toArary();
+        return $this->toArray();
     }
 
     /**

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -13,14 +13,52 @@ use Symfony\Component\Yaml\Yaml;
 class Definition extends AbstractKeyValueStore
 {
     /**
+     * @var string
+     */
+    private $basepath;
+
+    /**
      * Convert Yaml file to a Definition.
-     *
-     * @param string $filePath
      *
      * @return static
      */
     public static function fromYamlFile(string $filePath): self
     {
-        return new static(Yaml::parseFile($filePath));
+        $instance = new static(Yaml::parseFile($filePath));
+        $instance->setBasepath(\dirname($filePath));
+
+        return $instance;
+    }
+
+    /**
+     * Make sure to pass basepath into child definitions.
+     *
+     * {@inheritdoc}
+     */
+    public function get($lookup)
+    {
+        $value = parent::get($lookup);
+
+        if ($value instanceof self) {
+            $value->setBasepath($this->getBasepath());
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the directory name where definition YAML is stored.
+     */
+    public function getBasepath(): string
+    {
+        return $this->basepath;
+    }
+
+    /**
+     * Set path to directory containing definition YAML.
+     */
+    public function setBasepath(string $path): void
+    {
+        $this->basepath = realpath($path);
     }
 }

--- a/test/ContextTest.php
+++ b/test/ContextTest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 
 declare(strict_types=1);
 


### PR DESCRIPTION
Added `basepath` concept to the `Definition` class.

For now this makes sense: definitions are based on YAML files, so instances of `Definition` being able to infer the path where their YAML file is stored does not feel like a violation of concerns. However, if this concept fits better in another part of the project I would not object to it being moved.

Adding `JsonSerializable` interface will make dumping debug information relatively straight forward in the (near) future.

Resolves #10