### PR TITLE
Fix Definition Iterator

### DIFF
--- a/bin/upward
+++ b/bin/upward
@@ -1,7 +1,12 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 
 declare(strict_types=1);
 
+use Magento\Upward\Controller;
 use Zend\Http\PhpEnvironment\Request;
 
 try {
@@ -16,5 +21,12 @@ if (!$upwardConfig) {
     exit(1);
 }
 
-$controller = new Magento\Upward\Controller(new Request(), $upwardConfig);
-echo $controller();
+$controller = new Controller(new Request(), $upwardConfig);
+$response   = $controller();
+
+header($response->renderStatusLine());
+foreach ($response->getHeaders() as $header) {
+    header($header->toString());
+}
+
+echo $response->getBody();

--- a/src/AbstractKeyValueStore.php
+++ b/src/AbstractKeyValueStore.php
@@ -58,8 +58,10 @@ abstract class AbstractKeyValueStore implements \JsonSerializable
 
     /**
      * Does $lookup exist in this store?
+     *
+     * @param string|mixed $lookup
      */
-    public function has(string $lookup): bool
+    public function has($lookup): bool
     {
         $subArray = $this->data;
 
@@ -87,13 +89,14 @@ abstract class AbstractKeyValueStore implements \JsonSerializable
     /**
      * Assign a new key in store.
      *
+     * @param string $lookup
      *
      * @throws RuntimeException if $lookup is empty
      * @throws RuntimeException if $lookup is already set
      * @throws RuntimeException if an existing parent of lookup is a scalar value
      *                          (would effectively overwrite an existing value)
      */
-    public function set($lookup, $value): void
+    public function set(string $lookup, $value): void
     {
         $lookup = trim($lookup);
 

--- a/src/AbstractKeyValueStore.php
+++ b/src/AbstractKeyValueStore.php
@@ -89,7 +89,6 @@ abstract class AbstractKeyValueStore implements \JsonSerializable
     /**
      * Assign a new key in store.
      *
-     * @param string $lookup
      *
      * @throws RuntimeException if $lookup is empty
      * @throws RuntimeException if $lookup is already set

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -3,15 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 declare(strict_types=1);
 
 namespace Magento\Upward;
 
 class Controller
 {
-    /** @var \Zend\Http\PhpEnvironment\Request */
-    private $request;
-
     /** @var Context */
     private $context;
 
@@ -21,20 +19,21 @@ class Controller
     /** @var DefinitionIterator */
     private $definitionIterator;
 
+    /** @var \Zend\Http\PhpEnvironment\Request */
+    private $request;
+
     public function __construct(
         \Zend\Http\PhpEnvironment\Request $request,
         string $upwardConfig
     ) {
-        $this->request = $request;
-        $this->context = Context::fromRequest($request);
-        $this->definition = Definition::fromYamlFile($upwardConfig);
+        $this->request            = $request;
+        $this->context            = Context::fromRequest($request);
+        $this->definition         = Definition::fromYamlFile($upwardConfig);
         $this->definitionIterator = new DefinitionIterator($this->definition, $this->context);
     }
 
     /**
-     * Executes request and returns response
-     *
-     * @return \Zend\Http\Response
+     * Executes request and returns response.
      */
     public function __invoke(): \Zend\Http\Response
     {

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -17,7 +17,22 @@ class Definition extends AbstractKeyValueStore
      */
     private $basepath;
 
-    private $lookup = '';
+    /**
+     * @var string
+     */
+    private $treeAddress = '';
+
+    /**
+     * Set basepath to cwd on init.
+     *
+     * {@inheritdoc}
+     */
+    public function __construct(array $data)
+    {
+        $this->setBasepath(getcwd());
+
+        parent::__construct($data);
+    }
 
     /**
      * Convert Yaml file to a Definition.
@@ -43,7 +58,7 @@ class Definition extends AbstractKeyValueStore
 
         if ($value instanceof self) {
             $value->setBasepath($this->getBasepath());
-            $value->lookup = (empty($this->lookup) ? '' : $this->lookup . '.') . $lookup;
+            $value->treeAddress = (empty($this->treeAddress) ? '' : $this->treeAddress . '.') . $lookup;
         }
 
         return $value;
@@ -57,9 +72,12 @@ class Definition extends AbstractKeyValueStore
         return $this->basepath;
     }
 
-    public function getLookupPath(): string
+    /**
+     * Get a dot separated address of where this node belongs in the definition tree.
+     */
+    public function getTreeAddress(): string
     {
-        return $this->lookup;
+        return $this->treeAddress;
     }
 
     /**

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -17,6 +17,8 @@ class Definition extends AbstractKeyValueStore
      */
     private $basepath;
 
+    private $lookup = '';
+
     /**
      * Convert Yaml file to a Definition.
      *
@@ -41,6 +43,7 @@ class Definition extends AbstractKeyValueStore
 
         if ($value instanceof self) {
             $value->setBasepath($this->getBasepath());
+            $value->lookup = (empty($this->lookup) ? '' : $this->lookup . '.') . $lookup;
         }
 
         return $value;
@@ -52,6 +55,11 @@ class Definition extends AbstractKeyValueStore
     public function getBasepath(): string
     {
         return $this->basepath;
+    }
+
+    public function getLookupPath(): string
+    {
+        return $this->lookup;
     }
 
     /**

--- a/src/DefinitionIterator.php
+++ b/src/DefinitionIterator.php
@@ -34,15 +34,21 @@ class DefinitionIterator
     /**
      * Travserse the Definition for a value, using a resolver if necessary.
      *
-     * @param string|mixed $lookup
-     * @param bool         $updateContext Store result from Definition & Resolver in Context
+     * @param string|mixed           $lookup
+     * @param string                 $parentPath    Path before $lookup, used when iterating into child Definitions
+     * @param Definition|string|null $definition    Definition to iterate rather than root definition
+     * @param bool                   $updateContext Store result from Definition & Resolver in Context
      *
      * @throws RuntimeException if iterator is already attempting to resolve $lookup
      *                          (ie, definition appears to contain a loop)
      * @throws RuntimeException if $lookup does not exist in definition
      */
-    public function get($lookup, bool $updateContext = true)
-    {
+    public function get(
+        $lookup,
+        string $parentPath = '',
+        $definition = null,
+        bool $updateContext = true
+    ) {
         if ($this->context->has($lookup)) {
             return $this->context->get($lookup);
         }
@@ -51,13 +57,19 @@ class DefinitionIterator
             throw new \RuntimeException('Definition appears to contain a loop: ' . json_encode($this->lookupStack));
         }
 
-        $this->lookupStack[] = $lookup;
-
-        $definition = $this->definition->get($lookup);
+        $definition = $definition ?? $this->definition->get($lookup);
 
         if ($definition === null) {
             throw new \RuntimeException('No definition for ' . (is_scalar($lookup) ? $lookup : \gettype($lookup)));
         }
+
+        if ($this->context->isBuiltinValue($definition)) {
+            $this->context->set($lookup, $definition);
+
+            return $definition;
+        }
+
+        $this->lookupStack[] = (empty($parentPath) ? '' : $parentPath . '.') . $lookup;
 
         $resolver = ResolverFactory::get($definition);
 
@@ -73,12 +85,14 @@ class DefinitionIterator
 
         $value = $resolver->resolve($definition);
 
+        // Need to refactor this in the future; there's too much swapping between Definition & array types.
         if ($value instanceof Definition) {
             $value = $value->toArray();
 
-            array_walk($value, function (&$value, $key) use ($lookup): void {
-                // Don't update the Context; we'll take care of that below
-                $value = $this->get($lookup . '.' . $key, false);
+            array_walk($value, function (&$childValue, $key) use ($lookup): void {
+                $childDefinition = is_scalar($childValue) ? $childValue : new Definition($childValue);
+
+                $childValue = $this->get($key, $lookup, $childDefinition, false);
             });
         }
 

--- a/src/DefinitionIterator.php
+++ b/src/DefinitionIterator.php
@@ -64,7 +64,9 @@ class DefinitionIterator
         }
 
         if ($this->context->isBuiltinValue($definition)) {
-            $this->context->set($lookup, $definition);
+            if ($updateContext) {
+                $this->context->set($lookup, $definition);
+            }
 
             return $definition;
         }

--- a/src/DefinitionIterator.php
+++ b/src/DefinitionIterator.php
@@ -35,20 +35,15 @@ class DefinitionIterator
      * Travserse the Definition for a value, using a resolver if necessary.
      *
      * @param string|mixed           $lookup
-     * @param string                 $parentPath    Path before $lookup, used when iterating into child Definitions
-     * @param Definition|string|null $definition    Definition to iterate rather than root definition
      * @param bool                   $updateContext Store result from Definition & Resolver in Context
      *
      * @throws RuntimeException if iterator is already attempting to resolve $lookup
      *                          (ie, definition appears to contain a loop)
      * @throws RuntimeException if $lookup does not exist in definition
      */
-    public function get(
-        $lookup,
-        string $parentPath = '',
-        $definition = null,
-        bool $updateContext = true
-    ) {
+    public function get($lookup, $definition = null) {
+        $updateContext = false;
+
         if ($this->context->has($lookup)) {
             return $this->context->get($lookup);
         }
@@ -57,7 +52,10 @@ class DefinitionIterator
             throw new \RuntimeException('Definition appears to contain a loop: ' . json_encode($this->lookupStack));
         }
 
-        $definition = $definition ?? $this->definition->get($lookup);
+        if ($definition === null) {
+            $definition = $this->getRootDefinition()->get($lookup);
+            $updateContext = true;
+        }
 
         if ($definition === null) {
             throw new \RuntimeException('No definition for ' . (is_scalar($lookup) ? $lookup : \gettype($lookup)));
@@ -71,7 +69,7 @@ class DefinitionIterator
             return $definition;
         }
 
-        $this->lookupStack[] = (empty($parentPath) ? '' : $parentPath . '.') . $lookup;
+        $this->lookupStack[] = $definition->getLookupPath();
 
         $resolver = ResolverFactory::get($definition);
 
@@ -105,5 +103,10 @@ class DefinitionIterator
         array_pop($this->lookupStack);
 
         return $value;
+    }
+
+    public function getRootDefinition(): Definition
+    {
+        return $this->definition;
     }
 }

--- a/src/DefinitionIterator.php
+++ b/src/DefinitionIterator.php
@@ -79,20 +79,9 @@ class DefinitionIterator
 
         $resolver = ResolverFactory::get($definition);
 
-        // Treat $definition as an address for a different part of Definition tree
-        if ($resolver === null && is_scalar($definition)) {
-            $value = $this->get($definition);
-
-            if ($updateContext) {
-                $this->context->set($lookup, $value);
-            }
-
-            array_pop($this->lookupStack);
-
-            return $value;
-        }
-
-        $value = $this->getFromResolver($lookup, $definition, $resolver);
+        $value = ($resolver === null && is_scalar($definition))
+            ? $this->get($definition) // Treat $definition as an address for a different part of Definition tree
+            : $this->getFromResolver($lookup, $definition, $resolver);
 
         if ($updateContext) {
             $this->context->set($lookup, $value);

--- a/test/ContextTest.php
+++ b/test/ContextTest.php
@@ -22,16 +22,12 @@ class ContextTest extends TestCase
     public function builtinDataProvider(): array
     {
         return [
-            [true],
-            [false],
             ['GET'],
             ['POST'],
             ['mustache'],
             ['text/plain'],
             ['utf8'],
-            [100],
             ['100'],
-            [599],
             ['599'],
         ];
     }
@@ -92,5 +88,35 @@ class ContextTest extends TestCase
         $this->expectExceptionMessage('Cannot override a builtin value.');
 
         $subject->set($value, 'some value');
+    }
+
+    public function testIsBuiltinValue(): void
+    {
+        $subject = new Context([]);
+
+        verify($subject->isBuiltinValue('GET'))->is()->true();
+        verify($subject->isBuiltinValue('mustache'))->is()->true();
+        verify($subject->isBuiltinValue('utf8'))->is()->true();
+        verify($subject->isBuiltinValue('101'))->is()->true();
+        verify($subject->isBuiltinValue(201))->is()->true();
+
+        verify($subject->isBuiltinValue('some other value'))->is()->false();
+        verify($subject->isBuiltinValue('99'))->is()->false();
+        verify($subject->isBuiltinValue(700))->is()->false();
+        verify($subject->isBuiltinValue(3.14))->is()->false();
+        verify($subject->isBuiltinValue('6.28'))->is()->false();
+    }
+
+    public function testIsStatusCode(): void
+    {
+        $subject = new Context([]);
+
+        verify($subject->isStatusCode('101'))->is()->true();
+        verify($subject->isStatusCode(201))->is()->true();
+
+        verify($subject->isStatusCode('99'))->is()->false();
+        verify($subject->isStatusCode(700))->is()->false();
+        verify($subject->isStatusCode(3.14))->is()->false();
+        verify($subject->isStatusCode('6.28'))->is()->false();
     }
 }

--- a/test/ContextTest.php
+++ b/test/ContextTest.php
@@ -77,19 +77,6 @@ class ContextTest extends TestCase
         verify($subject->get($value))->is()->sameAs($value);
     }
 
-    /**
-     * @dataProvider builtinDataProvider
-     */
-    public function testSetBuiltin($value): void
-    {
-        $subject = new Context([]);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot override a builtin value.');
-
-        $subject->set($value, 'some value');
-    }
-
     public function testIsBuiltinValue(): void
     {
         $subject = new Context([]);
@@ -118,5 +105,18 @@ class ContextTest extends TestCase
         verify($subject->isStatusCode(700))->is()->false();
         verify($subject->isStatusCode(3.14))->is()->false();
         verify($subject->isStatusCode('6.28'))->is()->false();
+    }
+
+    /**
+     * @dataProvider builtinDataProvider
+     */
+    public function testSetBuiltin($value): void
+    {
+        $subject = new Context([]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot override a builtin value.');
+
+        $subject->set($value, 'some value');
     }
 }

--- a/test/ControllerTest.php
+++ b/test/ControllerTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 declare(strict_types=1);
 
 namespace Magento\Upward\Test;
@@ -15,41 +16,44 @@ use PHPUnit\Framework\TestCase;
 use Zend\Http\PhpEnvironment\Request;
 use function BeBat\Verify\verify;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class ControllerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function testInvokeValid()
+    public function testInvokeValid(): void
     {
-        $request = Mockery::mock(Request::class)->makePartial();
+        $request                = Mockery::mock(Request::class)->makePartial();
         $definitionIteratorMock = Mockery::mock('overload:' . DefinitionIterator::class);
         $definitionIteratorMock->shouldReceive('get')->once()->with('status')->andReturn(200);
         $definitionIteratorMock->shouldReceive('get')->once()->with('headers')->andReturn([
-            'content-type' => 'text/plain'
+            'content-type' => 'text/plain',
         ]);
         $definitionIteratorMock->shouldReceive('get')->once()->with('body')->andReturn('Response Body');
         $controller = new Controller($request, 'pwa/upward-config-sample.yml');
-        $response = $controller();
+        $response   = $controller();
         verify($response->getStatusCode())->is()->sameAs(200);
         verify($response->getHeaders())->isNot()->empty();
         verify($response->getContent())->is()->sameAs('Response Body');
     }
 
-    public function testInvokeWithException()
+    public function testInvokeWithException(): void
     {
-        $request = Mockery::mock(Request::class)->makePartial();
+        $request                = Mockery::mock(Request::class)->makePartial();
         $definitionIteratorMock = Mockery::mock('overload:' . DefinitionIterator::class);
         $definitionIteratorMock->shouldReceive('get')->once()->with('status')->andReturn(200);
         $definitionIteratorMock->shouldReceive('get')->once()->with('headers')->andReturn([
-            'content-type' => 'text/plain'
+            'content-type' => 'text/plain',
         ]);
         $definitionIteratorMock->shouldReceive('get')->once()->with('body')->andThrow(
             new \RuntimeException('Exception Message')
         );
         $controller = new Controller($request, 'pwa/upward-config-sample.yml');
-        $response = $controller();
+        $response   = $controller();
         verify($response->getStatusCode())->is()->sameAs(500);
         verify($response->getHeaders())->is()->empty();
-        verify($response->getContent())->is()->equalTo('Exception Message');
+        verify($response->getContent())->is()->sameAs('Exception Message');
     }
 }

--- a/test/DefinitionIteratorTest.php
+++ b/test/DefinitionIteratorTest.php
@@ -22,12 +22,24 @@ class DefinitionIteratorTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
+    /**
+     * DefinitionIterator
+     */
     private $iterator;
 
+    /**
+     * @var Context|Mockery\MockInterface
+     */
     private $mockContext;
 
+    /**
+     * @var Definition|Mockery\MockInterface
+     */
     private $mockDefinition;
 
+    /**
+     * @var ResolverFactory|Mockery\MockInterface
+     */
     private $mockResolverFactory;
 
     protected function setUp(): void
@@ -37,6 +49,10 @@ class DefinitionIteratorTest extends TestCase
         $this->mockResolverFactory = Mockery::mock('alias:' . ResolverFactory::class);
 
         $this->mockContext->shouldReceive('has')
+            ->with(Mockery::any())
+            ->andReturn(false)
+            ->byDefault();
+        $this->mockContext->shouldReceive('isBuiltinValue')
             ->with(Mockery::any())
             ->andReturn(false)
             ->byDefault();
@@ -60,6 +76,22 @@ class DefinitionIteratorTest extends TestCase
         $this->expectExceptionMessage('Definition appears to contain a loop');
 
         $this->iterator->get('lookup value');
+    }
+
+    public function testDefinitionIsBuiltIn(): void
+    {
+        $this->mockDefinition->shouldReceive('get')
+            ->with('lookup value')
+            ->andReturn('definition value');
+
+        $this->mockContext->shouldReceive('isBuiltinValue')
+            ->with('definition value')
+            ->andReturn(true);
+        $this->mockContext->shouldReceive('set')
+            ->with('lookup value', 'definition value')
+            ->once();
+
+        verify($this->iterator->get('lookup value'))->is()->sameAs('definition value');
     }
 
     public function testGetFromContext(): void
@@ -134,16 +166,16 @@ class DefinitionIteratorTest extends TestCase
             ->andReturn($childDefinition);
 
         $this->mockContext->shouldReceive('has')
-            ->with('lookup value.key1')
+            ->with('key1')
             ->andReturn(true);
         $this->mockContext->shouldReceive('has')
-            ->with('lookup value.key2')
+            ->with('key2')
             ->andReturn(true);
         $this->mockContext->shouldReceive('get')
-            ->with('lookup value.key1')
+            ->with('key1')
             ->andReturn('context value 1');
         $this->mockContext->shouldReceive('get')
-            ->with('lookup value.key2')
+            ->with('key2')
             ->andReturn('context value 2');
 
         $this->mockContext->shouldReceive('set')

--- a/test/DefinitionIteratorTest.php
+++ b/test/DefinitionIteratorTest.php
@@ -23,7 +23,7 @@ class DefinitionIteratorTest extends TestCase
     use MockeryPHPUnitIntegration;
 
     /**
-     * DefinitionIterator
+     * @var DefinitionIterator
      */
     private $iterator;
 
@@ -62,22 +62,6 @@ class DefinitionIteratorTest extends TestCase
         $this->iterator = new DefinitionIterator($this->mockDefinition, $this->mockContext);
     }
 
-    public function testDefinitionLoop(): void
-    {
-        $this->mockDefinition->shouldReceive('get')
-            ->with('lookup value')
-            ->andReturn('lookup value');
-
-        $this->mockResolverFactory->shouldReceive('get')
-            ->with('lookup value')
-            ->andReturnNull();
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Definition appears to contain a loop');
-
-        $this->iterator->get('lookup value');
-    }
-
     public function testDefinitionIsBuiltIn(): void
     {
         $this->mockDefinition->shouldReceive('get')
@@ -92,6 +76,22 @@ class DefinitionIteratorTest extends TestCase
             ->once();
 
         verify($this->iterator->get('lookup value'))->is()->sameAs('definition value');
+    }
+
+    public function testDefinitionLoop(): void
+    {
+        $this->mockDefinition->shouldReceive('get')
+            ->with('lookup value')
+            ->andReturn('lookup value');
+
+        $this->mockResolverFactory->shouldReceive('get')
+            ->with('lookup value')
+            ->andReturnNull();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Definition appears to contain a loop');
+
+        $this->iterator->get('lookup value');
     }
 
     public function testGetFromContext(): void

--- a/test/DefinitionIteratorTest.php
+++ b/test/DefinitionIteratorTest.php
@@ -141,7 +141,7 @@ class DefinitionIteratorTest extends TestCase
             ->with('resolver-definition')
             ->andReturn($mockResolver);
         $resolverFactory->shouldReceive('get')
-            ->with($childDefinition)
+            ->with('resolver-for-child')
             ->andReturn($mockResolver);
 
         $mockResolver->shouldReceive('setIterator')
@@ -150,7 +150,7 @@ class DefinitionIteratorTest extends TestCase
             ->with('resolver-definition')
             ->andReturn('resolver value');
         $mockResolver->shouldReceive('resolve')
-            ->with($childDefinition)
+            ->with('resolver-for-child')
             ->andReturn('child resolver value');
 
         verify($iterator->get('key'))->is()->sameAs('resolver value');

--- a/test/DefinitionTest.php
+++ b/test/DefinitionTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Upward\Test;
+
+use Magento\Upward\Definition;
+use PHPUnit\Framework\TestCase;
+use function BeBat\Verify\verify;
+
+class DefinitionTest extends TestCase
+{
+    /**
+     * @var Definition
+     */
+    private $definition;
+
+    protected function setUp(): void
+    {
+        $this->definition = new Definition([
+            'key0' => [
+                'key00' => [
+                    'key000' => 'value',
+                ],
+            ],
+        ]);
+
+        $this->definition->setBasepath(__DIR__);
+    }
+
+    public function testBasepathInheritance(): void
+    {
+        $this->assertionsForBasepath($this->definition->get('key0'));
+        $this->assertionsForBasepath($this->definition->get('key0.key00'));
+        $this->assertionsForBasepath($this->definition->get('key0')->get('key00'));
+    }
+
+    public function testTreeAddress(): void
+    {
+        verify($this->definition->get('key0'))->is()->instanceOf(Definition::class);
+        verify($this->definition->get('key0')->getTreeAddress())->is()->sameAs('key0');
+
+        verify($this->definition->get('key0.key00'))->is()->instanceOf(Definition::class);
+        verify($this->definition->get('key0.key00')->getTreeAddress())->is()->sameAs('key0.key00');
+
+        verify($this->definition->get('key0')->get('key00'))->is()->instanceOf(Definition::class);
+        verify($this->definition->get('key0')->get('key00')->getTreeAddress())->is()->sameAs('key0.key00');
+    }
+
+    private function assertionsForBasepath($subject): void
+    {
+        verify($subject)->is()->instanceOf(Definition::class);
+        verify($subject->getBasepath())->is()->sameAs(__DIR__);
+    }
+}


### PR DESCRIPTION
`DefinitionIterator` was attempting to resolve all keys from the root definition, so attempting to parse something like `headers.inline.content-type` would look for a key of `headers.content-type` and fail.

Lookups are now done relative to a child definition when passed.

Additionally: 
- Fixed `bin/upward` to set HTTP headers and status code
- Fixed issue when trying to run entire unit test suite (tests with overloaded or aliased classes must run in separate process)