### PR TITLE
Fix bugs found when using venia-upward.yml:

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "OSL-3.0",
     "require": {
         "php": ">= 7.1",
-        "guzzlehttp/guzzle": "^6.2",
         "mustache/mustache": "^2.12",
+        "ralouphie/mimey": "^2.0",
         "symfony/yaml": "^2.3||^3.3",
         "zendframework/zend-http": "^2.6",
         "zendframework/zend-stdlib": "^2.7"
@@ -22,6 +22,9 @@
         {
             "name": "Ben Batschelet",
             "email": "batschel@adobe.com"
+        }, {
+            "name": "Tommy Wiebell",
+            "email": "twiebell@adobe.com"
         }
     ],
     "autoload": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
       "dev": true
     },
     "@babel/runtime-corejs2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.2.0.tgz",
-      "integrity": "sha512-kPfmKoRI8Hpo5ZJGACWyrc9Eq1j3ZIUpUAQT2yH045OuYpccFJ9kYA/eErwzOM2jeBG1sC8XX1nl1EArtuM8tg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.3.1.tgz",
+      "integrity": "sha512-YpO13776h3e6Wy8dl2J8T9Qwlvopr+b4trCEhHE+yek6yIqV8sx6g3KozdHMbXeBpjosbPi+Ii5Z7X9oXFHUKA==",
       "dev": true,
       "requires": {
         "core-js": "^2.5.7",
@@ -31,9 +31,9 @@
       }
     },
     "@magento/upward-spec": {
-      "version": "2.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@magento/upward-spec/-/upward-spec-2.0.0-rc.17.tgz",
-      "integrity": "sha512-B5+qaZAbxJhSCcuIy3/CBcDv2DNJXgwgnIUsybEAzZKm+U3Iq/AGlAhNhexrnra1vmZUE5cQv8lCC+mMp7gf2w==",
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@magento/upward-spec/-/upward-spec-2.0.0-rc.18.tgz",
+      "integrity": "sha512-sFqPruVzqV7bXkShqxDxRypw4wY1O/NAfG7aAbYbR4LoRE1hdxxRBCtZvassKm5gyyjZ2BzHdcvSlQnNvuiHvA==",
       "dev": true,
       "requires": {
         "apollo-server": "~2.0.5",
@@ -150,9 +150,9 @@
       }
     },
     "@types/events": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
     "@types/express": {
@@ -167,12 +167,11 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
-      "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.1.tgz",
+      "integrity": "sha512-QgbIMRU1EVRry5cIu1ORCQP4flSYqLM1lS5LYyGWfKnFT3E58f0gKto7BR13clBFVrVZ0G0rbLZ1hUpSkgQQOA==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/node": "*",
         "@types/range-parser": "*"
       }
@@ -393,12 +392,13 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.27.tgz",
-      "integrity": "sha512-nzrMQ89JMpNmYnVGJ4t8zN75gQbql27UDhlxNi+3OModp0Masx5g+fQmQJ5B4w2dpRuYOsdwFLmj3lQbwOKV1Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.1.2.tgz",
+      "integrity": "sha512-EjDx8vToK+zkWIxc76ZQY/irRX52puNg04xf/w8R0kVTDAgHuVfnFVC01O5vE25kFnIaa5em0pFI0p9b6YMkhQ==",
       "dev": true,
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "fast-json-stable-stringify": "^2.0.0",
+        "tslib": "^1.9.3"
       }
     },
     "argparse": {
@@ -544,9 +544,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
-      "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
       "dev": true
     },
     "core-util-is": {
@@ -874,9 +874,9 @@
       }
     },
     "graphql-tag": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.0.tgz",
-      "integrity": "sha512-9FD6cw976TLLf9WYIUPCaaTpniawIjHWZSwIRZSjrfufJamcXbVVYfN2TWvJYbw0Xf2JjYbl1/f2+wDnBVw3/w==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==",
       "dev": true
     },
     "graphql-tools": {
@@ -1700,6 +1700,12 @@
         }
       }
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
@@ -1787,9 +1793,9 @@
       "dev": true
     },
     "zen-observable": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",
-      "integrity": "sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.13.tgz",
+      "integrity": "sha512-fa+6aDUVvavYsefZw0zaZ/v3ckEtMgCFi30sn91SEZea4y/6jQp05E3omjkX91zV6RVdn15fqnFZ6RKjRGbp2g==",
       "dev": true
     },
     "zen-observable-ts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "test:spec": "upward-spec ./test-spec.sh"
   },
   "devDependencies": {
-    "@magento/upward-spec": "~2.0.0-rc.17"
+    "@magento/upward-spec": "^2.0.0-rc.18"
   }
 }

--- a/src/DefinitionIterator.php
+++ b/src/DefinitionIterator.php
@@ -85,16 +85,14 @@ class DefinitionIterator
             $definedValue = $definedValue->get($lookup);
         }
 
-        // Expand $lookup to full tree address so we can safely detect loops across different parts of the tree
-        if ($definedValue instanceof Definition) {
-            $lookup = $definedValue->getTreeAddress();
-        }
-
         if (\in_array($lookup, $this->lookupStack)) {
-            throw new \RuntimeException('Definition appears to contain a loop: ' . json_encode($this->lookupStack));
+            $stack = array_merge($this->lookupStack, [$lookup]);
+            throw new \RuntimeException('Definition appears to contain a loop: ' . json_encode($stack));
         }
 
-        $this->lookupStack[] = $lookup;
+        $this->lookupStack[] = empty($definition->getTreeAddress())
+            ? $lookup
+            : $definition->getTreeAddress() . '.' . $lookup;
 
         try {
             $value = $this->getFromDefinedValue($lookup, $definedValue);

--- a/src/DefinitionIterator.php
+++ b/src/DefinitionIterator.php
@@ -85,14 +85,14 @@ class DefinitionIterator
             $definedValue = $definedValue->get($lookup);
         }
 
-        if (\in_array($lookup, $this->lookupStack)) {
+        $fullLookup = empty($definition->getTreeAddress()) ? $lookup : $definition->getTreeAddress() . '.' . $lookup;
+
+        if (\in_array($fullLookup, $this->lookupStack)) {
             $stack = array_merge($this->lookupStack, [$lookup]);
             throw new \RuntimeException('Definition appears to contain a loop: ' . json_encode($stack));
         }
 
-        $this->lookupStack[] = empty($definition->getTreeAddress())
-            ? $lookup
-            : $definition->getTreeAddress() . '.' . $lookup;
+        $this->lookupStack[] = $fullLookup;
 
         try {
             $value = $this->getFromDefinedValue($lookup, $definedValue);

--- a/src/Resolver/Conditional.php
+++ b/src/Resolver/Conditional.php
@@ -64,8 +64,9 @@ class Conditional extends AbstractResolver
         }
 
         foreach ($definition->get($this->getIndicator()) as $matcher) {
-            $value   = (string) $this->getIterator()->get($matcher->get('matches'));
-            $pattern = '/' . addcslashes($matcher->get('pattern'), '/') . '/';
+            $rawValue = $this->getIterator()->get($matcher->get('matches'));
+            $value    = is_scalar($rawValue) ? (string) $rawValue : json_encode($rawValue);
+            $pattern  = '/' . addcslashes($matcher->get('pattern'), '/') . '/';
 
             if (preg_match($pattern, $value, $matches)) {
                 // preface each key with '$'

--- a/src/Resolver/Directory.php
+++ b/src/Resolver/Directory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Magento\Upward\Resolver;
 
 use Magento\Upward\Definition;
+use Mimey\MimeTypes;
 use Zend\Http\Header\ContentType;
 use Zend\Http\Response;
 use Zend\Http\Response\Stream;
@@ -53,8 +54,7 @@ class Directory extends AbstractResolver
             throw new \InvalidArgumentException('$definition must be an instance of ' . Definition::class);
         }
 
-        $directory = $this->getIterator()->get('directory', $definition);
-
+        $directory  = $this->getIterator()->get('directory', $definition);
         $response   = new Stream();
         $upwardRoot = $this->getIterator()->getRootDefinition()->getBasepath();
         $root       = realpath($upwardRoot . \DIRECTORY_SEPARATOR . $directory);
@@ -64,8 +64,10 @@ class Directory extends AbstractResolver
         if (!$path || strpos($path, $root) !== 0 || !is_file($path)) {
             $response->setStatusCode(Response::STATUS_CODE_404);
         } else {
+            $mimeType = (new MimeTypes())->getMimeType(pathinfo($path, PATHINFO_EXTENSION));
+
             $response->setStream(fopen($path, 'r'));
-            $response->getHeaders()->addHeader(new ContentType(mime_content_type($path)));
+            $response->getHeaders()->addHeader(new ContentType($mimeType));
         }
 
         return $response;

--- a/src/Resolver/Proxy.php
+++ b/src/Resolver/Proxy.php
@@ -60,6 +60,7 @@ class Proxy extends AbstractResolver
         $client = new Client(null, [
             'adapter'     => Client\Adapter\Curl::class,
             'curloptions' => [
+                CURLOPT_SSL_VERIFYHOST => !$ignoreSSLErrors,
                 CURLOPT_SSL_VERIFYPEER => !$ignoreSSLErrors,
             ],
         ]);

--- a/src/Resolver/Proxy.php
+++ b/src/Resolver/Proxy.php
@@ -60,7 +60,7 @@ class Proxy extends AbstractResolver
         $client = new Client(null, [
             'adapter'     => Client\Adapter\Curl::class,
             'curloptions' => [
-                CURLOPT_SSL_VERIFYHOST => !$ignoreSSLErrors,
+                CURLOPT_SSL_VERIFYHOST => $ignoreSSLErrors ? 0 : 2,
                 CURLOPT_SSL_VERIFYPEER => !$ignoreSSLErrors,
             ],
         ]);

--- a/src/Resolver/Service.php
+++ b/src/Resolver/Service.php
@@ -69,7 +69,7 @@ class Service extends AbstractResolver
         $client = new Client($url, [
             'adapter'     => Client\Adapter\Curl::class,
             'curloptions' => [
-                CURLOPT_SSL_VERIFYHOST => !$ignoreSSLErrors,
+                CURLOPT_SSL_VERIFYHOST => $ignoreSSLErrors ? 0 : 2,
                 CURLOPT_SSL_VERIFYPEER => !$ignoreSSLErrors,
             ],
         ]);

--- a/src/Resolver/Template.php
+++ b/src/Resolver/Template.php
@@ -50,13 +50,18 @@ class Template extends AbstractResolver
     {
         $engineName     = $definition->has('engine') ? $this->getIterator()->get('engine', $definition) : null;
         $templateString = $this->getIterator()->get('template', $definition);
-        $renderData     = $this->getIterator()->get('provide', $definition);
+        $renderData     = [];
 
-        if ($definition->get('provide')->isList()) {
-            $renderData = array_combine($definition->get('provide')->toArray(), $renderData);
+        if ($definition->has('provide')) {
+            foreach ($definition->get('provide') as $index => $definition) {
+                $key              = \is_int($index) ? $definition : $index;
+                $renderData[$key] = $definition instanceof Definition
+                    ? $this->getIterator()->get('provide.' . $index)
+                    : $this->getIterator()->get($definition);
+            }
         }
 
-        $engine = TemplateFactory::get($definition->getBasepath(), $engineName);
+        $engine = TemplateFactory::get($this->getIterator()->getRootDefinition()->getBasepath(), $engineName);
 
         return $engine->render($templateString, $renderData);
     }

--- a/test/DefinitionIteratorTest.php
+++ b/test/DefinitionIteratorTest.php
@@ -93,7 +93,7 @@ class DefinitionIteratorTest extends TestCase
         // Key has been added to context
         verify($context->get('key'))->is()->true();
 
-        verify($iterator->get('child-key', false))->is()->false();
+        verify($iterator->get('child-key', new Definition(['child-key' => false])))->is()->false();
 
         // Key was not added to context
         verify($context->has('child-key'))->is()->false();
@@ -157,7 +157,7 @@ class DefinitionIteratorTest extends TestCase
         verify($context->get('key2'))->is()->true();
 
         // Child definition is an address for a value in the root definition
-        verify($iterator->get('key3', 'key4'))->is()->false();
+        verify($iterator->get('key3', new Definition(['key3' => 'key4'])))->is()->false();
 
         // Only value from root definition is added to context
         verify($context->has('key3'))->is()->false();

--- a/test/Resolver/ServiceTest.php
+++ b/test/Resolver/ServiceTest.php
@@ -87,7 +87,7 @@ class ServiceTest extends TestCase
 
         $zendClientMock = Mockery::mock('overload:' . Client::class);
         $zendClientMock->shouldReceive('setMethod')->with('POST');
-        $zendClientMock->shouldReceive('setHeaders')->with([]);
+        $zendClientMock->shouldReceive('setHeaders')->with(['Content-type' => 'application/json']);
         $zendClientMock->shouldReceive('setRawBody')->with($expectedRequestBody);
         $zendClientMock->shouldReceive('send')->andReturn($responseMock);
 
@@ -132,7 +132,8 @@ class ServiceTest extends TestCase
 
         $zendClientMock = Mockery::mock('overload:' . Client::class);
         $zendClientMock->shouldReceive('setMethod')->with('GET');
-        $zendClientMock->shouldReceive('setHeaders')->with(['header' => 'headerValue']);
+        $zendClientMock->shouldReceive('setHeaders')
+            ->with(['Content-type' => 'application/json', 'header' => 'headerValue']);
         $zendClientMock->shouldReceive('setParameterGet')->with($expectedRequestBody);
         $zendClientMock->shouldReceive('send')->andReturn($responseMock);
 

--- a/test/Resolver/ServiceTest.php
+++ b/test/Resolver/ServiceTest.php
@@ -133,7 +133,7 @@ class ServiceTest extends TestCase
         $zendClientMock = Mockery::mock('overload:' . Client::class);
         $zendClientMock->shouldReceive('setMethod')->with('GET');
         $zendClientMock->shouldReceive('setHeaders')
-            ->with(['Content-type' => 'application/json', 'header' => 'headerValue']);
+            ->with(['header' => 'headerValue']);
         $zendClientMock->shouldReceive('setParameterGet')->with($expectedRequestBody);
         $zendClientMock->shouldReceive('send')->andReturn($responseMock);
 

--- a/test/Resolver/TemplateTest.php
+++ b/test/Resolver/TemplateTest.php
@@ -111,13 +111,7 @@ class TemplateTest extends TestCase
             'engine'   => 'mustache',
             'template' => 'My Template',
             'provide'  => [
-                'resolver' => 'inline',
-                'inline'   => [
-                    'inlineKey' => [
-                        'resolver' => 'inline',
-                        'inline'   => 'inlineValue',
-                    ],
-                ],
+                'inlineKey' => 'some.lookup',
             ],
         ]);
 
@@ -130,6 +124,12 @@ class TemplateTest extends TestCase
         $this->definitionIteratorMock->shouldReceive('get')
             ->with('provide', $definition)
             ->andReturn(['inlineKey' => 'inlineValue']);
+        $this->definitionIteratorMock->shouldReceive('get')
+            ->with('some.lookup')
+            ->andReturn('inlineValue');
+
+        $this->definitionIteratorMock->shouldReceive('getRootDefinition')
+            ->andReturn($definition);
 
         $templateFactoryMock->shouldReceive('get')
             ->with($definition->getBasepath(), 'mustache')
@@ -161,8 +161,11 @@ class TemplateTest extends TestCase
             ->with('template', $definition)
             ->andReturn($definition->get('template'));
         $this->definitionIteratorMock->shouldReceive('get')
-            ->with('provide', $definition)
-            ->andReturn(['resolvedRootValue']);
+            ->with('rootValue')
+            ->andReturn('resolvedRootValue');
+
+        $this->definitionIteratorMock->shouldReceive('getRootDefinition')
+            ->andReturn($definition);
 
         $templateFactoryMock->shouldReceive('get')
             ->with($definition->getBasepath(), null)


### PR DESCRIPTION
- Cleanup composer.json
- Correctly detect MIME types in Directory resolver
- Update @magento/upward-spec
- Fix definition loop detection
- Fix handling non-scalar values in Conditional resolver
- Ignore more SSL certs problems
- Add support for ignoreSSLErrors in Service resolver
- Set Content-type to application/json by default in Service resolver
- Revise handling of provided variables in Template resolver
- Make DefinitionIterator tests more inline with real world scenarios