### PR TITLE
Conditional Fall Through

### DIFF
--- a/src/DefinitionIterator.php
+++ b/src/DefinitionIterator.php
@@ -42,14 +42,15 @@ class DefinitionIterator
     }
 
     /**
-     * Travserse the Definition for a value, using a resolver if necessary.
+     * Traverse the Definition for a value, using a resolver if necessary.
      *
      * @param string|mixed           $lookup
      * @param Definition|string|null $definition Definition to iterate rather than root definition
      *
-     * @throws RuntimeException if iterator is already attempting to resolve $lookup
-     *                          (ie, definition appears to contain a loop)
-     * @throws RuntimeException if $lookup does not exist in definition
+     * @throws \RuntimeException if iterator is already attempting to resolve $lookup
+     *                           (ie, definition appears to contain a loop)
+     * @throws \RuntimeException if $lookup does not exist in definition
+     * @throws \Exception        if lookup is undefined in the context
      */
     public function get($lookup, $definition = null)
     {

--- a/src/Resolver/Conditional.php
+++ b/src/Resolver/Conditional.php
@@ -64,9 +64,14 @@ class Conditional extends AbstractResolver
         }
 
         foreach ($definition->get($this->getIndicator()) as $matcher) {
-            $rawValue = $this->getIterator()->get($matcher->get('matches'));
-            $value    = is_scalar($rawValue) ? (string) $rawValue : json_encode($rawValue);
-            $pattern  = '/' . addcslashes($matcher->get('pattern'), '/') . '/';
+            try {
+                $rawValue = $this->getIterator()->get($matcher->get('matches'));
+            } catch (\Exception $exception) {
+                // exceptions thrown for match value lookups should silently fail and fall through
+                continue;
+            }
+            $value   = is_scalar($rawValue) ? (string) $rawValue : json_encode($rawValue);
+            $pattern = '/' . addcslashes($matcher->get('pattern'), '/') . '/';
 
             if (preg_match($pattern, $value, $matches)) {
                 // preface each key with '$'


### PR DESCRIPTION
@bbatsche and I agree that there's some issues in this logic, but given that this is how `upward-js` behaves, I think it's in our best interest to match that behavior until we have time to discuss this further. This change should be safe since it's isolated to the Conditional resolver only, all other failed lookups will continue throwing exceptions that halt request resolution.