### PR TITLE
Rename Composer package to upward-server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "magento/upward",
+    "name": "magento/upward-server",
     "description": "UPWARD parser and server",
     "type": "library",
     "license": "OSL-3.0",


### PR DESCRIPTION
See https://github.com/magento-research/magento2-upward-connector/pull/8#discussion_r258520857

>> @bbatsche: Once published, that should be accurate. The docs should be usable at release, and those packages won't be published yet, so we should leave this in place. Maybe call it a `git-based` installation for development purposes?
>> 
>> @zetlen: I think a Composer package implies that it's PHP, and would be redundant. A name change would be much more difficult post-release, so if you want to be concise and go `upward-server`, let's make it happen now.
>
> Thanks for that context. I anticipate more tools for UPWARD in various ecosystems so I would like to clarify this package's purpose by calling it `upward-server`.
