### PR TITLE
Make DirectoryResolver Response Cacheable

### DIFF
--- a/src/Resolver/Directory.php
+++ b/src/Resolver/Directory.php
@@ -68,7 +68,7 @@ class Directory extends AbstractResolver
 
             $response->setStream(fopen($path, 'r'));
             $response->getHeaders()->addHeader(new ContentType($mimeType));
-            $response->getHeaders()->addHeaderLine('Cache-Control', 'max-age=3600');
+            $response->getHeaders()->addHeaderLine('Cache-Control', 'max-age=31557600');
         }
 
         return $response;

--- a/src/Resolver/Directory.php
+++ b/src/Resolver/Directory.php
@@ -68,6 +68,7 @@ class Directory extends AbstractResolver
 
             $response->setStream(fopen($path, 'r'));
             $response->getHeaders()->addHeader(new ContentType($mimeType));
+            $response->getHeaders()->addHeaderLine('Cache-Control', 'max-age=3600');
         }
 
         return $response;

--- a/src/Resolver/Directory.php
+++ b/src/Resolver/Directory.php
@@ -68,6 +68,7 @@ class Directory extends AbstractResolver
 
             $response->setStream(fopen($path, 'r'));
             $response->getHeaders()->addHeader(new ContentType($mimeType));
+            // Enforce best practice and make sure static assets are cacheable
             $response->getHeaders()->addHeaderLine('Cache-Control', 'max-age=31557600');
         }
 

--- a/test/Resolver/DirectoryTest.php
+++ b/test/Resolver/DirectoryTest.php
@@ -100,6 +100,7 @@ class DirectoryTest extends TestCase
         verify($result)->is()->instanceOf(Response::class);
         verify($result->getStatusCode())->is()->sameAs(200);
         verify($result->getHeaders()->get('Content-Type')->getFieldValue())->is()->sameAs('text/plain');
+        verify($result->getHeaders()->get('Cache-Control')->getFieldValue())->is()->sameAs('max-age=31557600');
         verify($result->getBody())->is()->equalToFile(__DIR__ . '/_data/sample.txt');
     }
 


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description
Outlined in issue #52, resolvers were lacking caching headers, which was in turn causing some down stream issues in Fastly around text encoding/compression; which was dinging us on Lighthouse. I do think we should leave the issue open and have a general conversation about caching, because this issue is cross platform and also affects `upward-js`, but this resolve some Magento Cloud specific issues in the meantime.

As a starting point for, we're going to make the assumption that all static assets should be cached, and just hard-code this header into the Directory resolver.  

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[https://jira.corp.magento.com/browse/PWA-215](PWA-215)] Enable Text Compression (Lighthouse)

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Deploy to Magento Cloud (will require `feature/upward-dependency-testing` for `magento/module-upward-connector` dependency)
2. With Developer Console open, clear cache and open the app
3. Filter for a static asset like `client-<hash>.js` or `vendor-<hash>.js`
4. Verify `Cache-Control` header has a `max-age` value > 0
5. Verify `Content-Encoding` header value is `gzip`

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
