### PR TITLE
[PWA-528] 2.4.0 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">= 7.1",
         "mustache/mustache": "^2.12",
         "ralouphie/mimey": "^2.0",
-        "symfony/yaml": "^2.3 || ^3.3 || ^4.0",
+        "symfony/yaml": "^2.3 || ^3.3 || ^4.0 || ^5.0",
         "zendframework/zend-http": "^2.6",
         "zendframework/zend-stdlib": "^2.7 || ^3.2"
     },


### PR DESCRIPTION
### Description
Magento 2.4.0 will support PHP 7.4. PWA team need to analyze impact and see if any of our dependencies like upward-php, connector needs updates.

It would be good to start on this once 2.4.0-alpha package is available.

### Closes
* [[PWA-528](https://jira.corp.magento.com/browse/PWA-528)] PHP 7.4 support to analyze and test for PWA wrt Magento 2.4.0

### Dependent On
* magento-research/magento2-upward-connector#28

### Verification Steps

1. Install latest available alpha/beta of Magento 2.4.0
2. `composer require magento/module-upward-connector:dev-tommy/240-compat`
3. Enable module and configure path to `upward.yml`
4. Verify that the PWA works (except for Braintree 😉 )